### PR TITLE
Context wrapping + Cleanup

### DIFF
--- a/conditional_context/__init__.py
+++ b/conditional_context/__init__.py
@@ -95,6 +95,33 @@ class ConditionalContext(object):
             # Otherwise we return the wrapped __exit__ result
             return context_exit
 
+    def __getattribute__(self, name):
+        """Get all other attributes from wrappped context."""
+        # We can't just do self.context, will run into recursion
+        try:
+            context = super().__getattribute__("context")
+        except AttributeError:
+            context = None
+
+        if context is None or name in [
+            "_WARNING_IGNORED",
+            "__init__",
+            "__enter__",
+            "__exit__",
+            "should_skip",
+            "replace_should_skip",
+            "breakout",
+            "should_run",
+            "context",
+            "_orig_trace",
+            "skipped"
+        ]:
+            # Get actual attribute when not wrapping or when name is in list
+            return super().__getattribute__(name)
+        else:
+            # Get attribute from context when wrapping and when name is not in list
+            return type(self.context).__getattribute__(self.context, name)
+
 
 def condition(should_run=True, should_skip=None):
     """Context manager that can skip running the body of the context.

--- a/conditional_context/__init__.py
+++ b/conditional_context/__init__.py
@@ -3,12 +3,25 @@ import sys
 import inspect
 
 
-__all__ = ['ContextSkipError', 'ConditionalContext', 'condition', 'breakout']
+__all__ = ['ContextSkipError', 'breakout', 'ConditionalContext', 'condition', 'wrap']
 
 
 class ContextSkipError(Exception):
     def __init__(self, msg='Skip context block'):
         super().__init__(msg)
+
+
+# Module level function to break out of the body of a context without showing an error
+def breakout(*args, **kwargs):
+    """Break out of the body of a ConditionalContext without showing an error."""
+    raise ContextSkipError()
+
+
+def _settrace(func):
+    # Pydev actually writes to stderr instead of using a warning...
+    stderr, sys.stderr = sys.stderr, io.StringIO()
+    sys.settrace(func)
+    sys.stderr = stderr
 
 
 class ConditionalContext(object):
@@ -19,62 +32,68 @@ class ConditionalContext(object):
     Args:
         should_run (bool)[True]: If True the body of the context will run. If False the body of context will not run.
         should_skip (callable/function)[None]: If given this will replace the should_skip method.
+        context (class/context manager)[None]: If given, ConditionalContext will wrap this context.
     """
     _WARNING_IGNORED = False
 
-    def __init__(self, should_run=True, should_skip=None):
+    def __init__(self, should_run=True, should_skip=None, context=None):
         self.should_run = should_run
+        self.replace_should_skip(should_skip)
+        self.context = context
+        self.breakout = breakout
         self._orig_trace = None
         self.skipped = False
-        if should_skip is not None:
-            self.replace_should_skip(should_skip)
 
     def should_skip(self):
         """Return if the body of the context should be skipped."""
         return not self.should_run
 
-    orig_should_skip = should_skip
-
     def replace_should_skip(self, func):
-        """Function decorator to replace the should skip method."""
-        if func is None:
-            func = self.orig_should_skip
-        self.should_skip = func
-        return func
-
-    @staticmethod
-    def breakout(*args, **kwargs):
-        """Break out of the body of a ConditionalContext without showing an error."""
-        raise ContextSkipError()
-
-    trace = breakout
-
-    @staticmethod
-    def settrace(func):
-        # Pydev actually writes to stderr instead of using a warning...
-        stderr, sys.stderr = sys.stderr, io.StringIO()
-        sys.settrace(func)
-        sys.stderr = stderr
+        """Function decorator to replace the should_skip method."""
+        if func is not None:
+            self.should_skip = func
+        return self.should_skip
 
     def __enter__(self):
-        self.skipped = self.should_skip()
-        if self.skipped:
+        if self.should_skip():
             # Need to settrace to trigger the frame trace. Also need to reset trace after trace errors.
             self._orig_trace = sys.gettrace()
             if self._orig_trace is None:
-                self.settrace(lambda *args, **keys: None)  # Note: custom "self."settrace
+                _settrace(lambda *args, **keys: None)
 
             # Set a stack trace that will raise an error to skip the context block
             frame = inspect.currentframe().f_back
             frame.f_trace = self.breakout
-        return self
+            self.skipped = True
+
+        if self.context is None:
+            # Return ConditionalContext instance
+            return self
+        else:
+            # Use wrapped __enter__ behavior. Using self.context.__enter__() won't work
+            # because self would be a ConditionalContext instance, not type(self.context)
+            return type(self.context).__enter__(self.context)
 
     def __exit__(self, etype, value, traceback):
         # Reset the original trace method to resume debugging
         if self.skipped:
-            self.settrace(self._orig_trace)
+            _settrace(self._orig_trace)
             self._orig_trace = None
-        return etype == ContextSkipError or etype is None
+
+        # Get return of wrapped __exit__, if we are wrapping
+        if self.context is None:
+            context_exit = None
+        else:
+            # Using self.context.__exit__() won't work because self would be a
+            # ConditionalContext instance, not type(self.context)
+            context_exit = type(self.context).__exit__(self.context, etype, value, traceback)
+
+        if etype == ContextSkipError:
+            # Truthy return from __exit__ suppresses the error
+            return True
+        else:
+            # Otherwise we return the wrapped __exit__ result
+            return context_exit
 
 
 def condition(should_run=True, should_skip=None):
@@ -87,8 +106,18 @@ def condition(should_run=True, should_skip=None):
     Returns:
         ctx (ConditionalContext): Context manager class that can skip running the body of the context.
     """
-    return ConditionalContext(should_run, should_skip)
+    return ConditionalContext(should_run=should_run, should_skip=should_skip)
 
 
-# Module level function to break out of the body of a context without showing an error
-breakout = ConditionalContext.breakout
+def wrap(context, should_run=True, should_skip=None):
+    """Context manager that can skip running the body of the context.
+
+    Args:
+        context (class/context manager): The context to be wrapped in a ConditionalContext.
+        should_run (bool)[True]: If True the body of the context will run. If False the body of context will not run.
+        should_skip (callable/function)[None]: If given this will replace the should_skip method.
+
+    Returns:
+        ctx (ConditionalContext): Context manager class that can skip running the body of the context. Keeps the context functionality of wrapped context.
+    """
+    return ConditionalContext(should_run=should_run, should_skip=should_skip, context=context)


### PR DESCRIPTION
I had been looking for something like this project for a while, but when I noticed it only broke out of `with` blocks without the possibility to wrap another context manager I felt a bit disappointed... A lot of potential for a little more than a glorified `if` statement...

All previous functionality remains unchanged. I ran all of the tests I could find here and on PyPi, and also some of my own, all ran with no issues.

However this introduces `conditional_context.wrap()` (and a `context` argument for `ConditionalContext`) allowing to skip `with` blocks while making use of another context manager:
```python
import conditional_context


print('start')
with conditional_context.wrap(open('test.txt', 'a'), False) as f:
    print('here')  # Will not print
    f.write('here') # Will not write to file
print('end')


print('start 2')
with conditional_context.wrap(open('test.txt', 'a'), True) as f:
    print('here 2')  # Will print
    f.write('here 2') # Will write to file
print('end 2')
```

This of courrse means that when a wrapped context is passed, the with statement will receive the wrapped context's `__enter__()` result, not the `ConditionalContext` instance. As a consequence, when wrapping a context it is not possible to use the `.breakout()` method from the context, only from the module:
```python
import conditional_context


value1 = True
value2 = True
with conditional_context.condition() as ctx:
    value1 = False
    ctx.breakout()  # Remains unchanged
    value2 = False
assert value1 is False
assert value2 is True


value1 = True
value2 = True
with conditional_context.wrap(open('test.txt', 'a'), True) as f:
    value1 = False
    # f.breakout() does not exist, instead we need to use:
    conditional_context.breakout()
    value2 = False
assert value1 is False
assert value2 is True
```